### PR TITLE
Update CI tests to current Node/Ubuntu versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,8 @@ jobs:
     name: Run tests
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
-        node: [12, 14, 15, 16, 18, 19]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-latest, windows-latest]
+        node: [18, 20, 22]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
- Remove CI tests for Node v12, v14, v15, v16, v19
- Add CI tests for Node v20, v22.
- Update CI tests Ubuntu version